### PR TITLE
Added `call` and `apply`

### DIFF
--- a/lib/apply.js
+++ b/lib/apply.js
@@ -1,0 +1,9 @@
+module.exports = apply
+
+function apply(fn, args) {
+  if (!isFn(fn)) throw new TypeError('First argument must be a function.')
+
+  fn.apply(this, args)
+}
+
+const isFn  = require('./isFn')

--- a/lib/call.js
+++ b/lib/call.js
@@ -1,0 +1,4 @@
+const variadic = require('./variadic')
+    , apply    = require('./apply')
+
+module.exports = variadic(apply)

--- a/test/apply.js
+++ b/test/apply.js
@@ -1,0 +1,79 @@
+describe('apply', function() {
+  describe('when not given a function', function() {
+    it('should throw a TypeError', function() {
+      each(
+        [ 0
+        , 1
+        , []
+        , {}
+        , true
+        , false
+        , null
+        , undefined
+        ]
+        , function(nonfn) {
+          expect(function() {
+            apply(nonfn)
+          }).to.throw(TypeError)
+        }
+      )
+    })
+  })
+
+  describe('when given a function `fn`', function() {
+    describe('and no arguments', function(done) {
+      it('should call the function without arguments', function(done) {      
+        const fn = function() {
+          expect(arguments.length).to.equal(0)
+          done()
+        }
+
+        apply(fn)
+      })
+
+      describe('and `fn` is bound', function() {
+        it('should not affect the binding', function(done) {
+          const owner = {}
+
+          const fn = function() {
+            expect(arguments.length).to.equal(0)
+            expect(this).to.equal(owner)
+            done()
+          }
+
+          apply(fn.bind(owner))
+        })
+      })
+    })
+
+    describe('and when given arguments', function(done) {
+      it('should call the function with arguments', function(done) {
+        const fn = function() {
+          expect(slice(arguments)).to.eql([1, true, 'wibble'])
+          done()
+        }
+
+        apply(fn, [1, true, 'wibble'])
+      })
+
+      describe('and `fn` is bound', function() {
+        it('should not affect the binding', function(done) {
+          const owner = {}
+
+          const fn = function() {
+            expect(slice(arguments)).to.eql([1, true, 'wibble'])
+            expect(this).to.equal(owner)
+            done()
+          }
+
+          apply(fn.bind(owner), [1, true, 'wibble'])
+        })
+      })
+    })
+  })
+})
+
+const expect = require('chai').expect
+    , slice  = require('../lib/slice')
+    , apply  = require('../lib/apply')
+    , each   = require('../lib/each')

--- a/test/call.js
+++ b/test/call.js
@@ -1,0 +1,79 @@
+describe('call', function() {
+  describe('when not given a function', function() {
+    it('should throw a TypeError', function() {
+      each(
+        [ 0
+        , 1
+        , []
+        , {}
+        , true
+        , false
+        , null
+        , undefined
+        ]
+        , function(nonfn) {
+          expect(function() {
+            call(nonfn)
+          }).to.throw(TypeError)
+        }
+      )
+    })
+  })
+
+  describe('when given a function `fn`', function() {
+    describe('and no arguments', function(done) {
+      it('should call the function without arguments', function(done) {      
+        const fn = function() {
+          expect(arguments.length).to.equal(0)
+          done()
+        }
+
+        call(fn)
+      })
+
+      describe('and `fn` is bound', function() {
+        it('should not affect the binding', function(done) {
+          const owner = {}
+
+          const fn = function() {
+            expect(arguments.length).to.equal(0)
+            expect(this).to.equal(owner)
+            done()
+          }
+
+          call(fn.bind(owner))
+        })
+      })
+    })
+
+    describe('and when given arguments', function(done) {
+      it('should call the function with arguments', function(done) {
+        const fn = function() {
+          expect(slice(arguments)).to.eql([1, true, 'wibble'])
+          done()
+        }
+
+        call(fn, 1, true, 'wibble')
+      })
+
+      describe('and `fn` is bound', function() {
+        it('should not affect the binding', function(done) {
+          const owner = {}
+
+          const fn = function() {
+            expect(slice(arguments)).to.eql([1, true, 'wibble'])
+            expect(this).to.equal(owner)
+            done()
+          }
+
+          call(fn.bind(owner), 1, true, 'wibble')
+        })
+      })
+    })
+  })
+})
+
+const expect = require('chai').expect
+    , slice  = require('../lib/slice')
+    , each   = require('../lib/each')
+    , call   = require('../lib/call')


### PR DESCRIPTION
The tests for these should be extended when more generic
sequence code is added. Also, it'd be nice to consolidate the
tests since they are so similar, but the flu says DRY is so
overrated.
