### PR TITLE
Enables `get` to work recursively if given an array as key

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -2,10 +2,20 @@ module.exports = get
 
 function get(map, key, notFound) {
   if (isnt(map)) return notFound
-  if (!map.hasOwnProperty(key)) return notFound
 
-  return map[key]
+  if (is(Array, key)) {
+    if (key.length) {
+      var next = get(map, key[0], no)
+      return next === no? notFound : get(next, key.slice(1), notFound)
+    } else {
+      return map
+    }
+  } else {
+    return map.hasOwnProperty(key)? map[key] : notFound
+  }
 }
 
-var isnt = require('./isnt')
-  , is   = require('./is')
+var assert = require('./assert')
+  , isnt   = require('./isnt')
+  , is     = require('./is')
+  , no     = {}

--- a/test/get.js
+++ b/test/get.js
@@ -12,7 +12,7 @@ describe('`get`', function() {
       })
     })
 
-    describe('and when the value of `key` is logically false', function() {
+    describe('and when the value of `map[key]` is logically false', function() {
       it('should still return the value of `key`', function() {
         each([null, undefined, false], function(x) {
           const map = { foo: x }
@@ -69,6 +69,16 @@ describe('`get`', function() {
           expect(get(nil, 'whatever', nope)).to.equal(nope)
         })
       })
+    })
+  })
+
+  describe('when given an array as `key`', function() {
+    it('should work recursively', function() {
+      const map = { a: { b: { c: { d: 'wibble' } } } }
+          , notFound = {}
+
+      expect(get(map, ['a', 'b', 'c', 'd'])).to.equal('wibble')
+      expect(get(map, ['a', 'b', 'c', 'x'], notFound)).to.equal(notFound)
     })
   })
 })


### PR DESCRIPTION
The array is treated as a path of property names to resolve, and
should any of them fail then `notFound` will be returned.